### PR TITLE
Turn on web session using app config 

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -2,3 +2,4 @@ appname = acme
 httpport = 8080
 runmode = dev
 enableadmin = true
+SessionOn = true

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	_ "acme/models"
 	_ "acme/routers"
 	"fmt"
+
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/orm"
 	_ "github.com/mattn/go-sqlite3"
@@ -22,6 +23,5 @@ func init() {
 }
 
 func main() {
-	beego.BConfig.WebConfig.Session.SessionOn = true
 	beego.Run()
 }


### PR DESCRIPTION
Turn on web session using 'SessionOn = true' in conf/app.conf
instead of using beego.BConfig.WebConfig.Session.SessionOn in main.go